### PR TITLE
Build groups staging rpm

### DIFF
--- a/groups/pom.xml
+++ b/groups/pom.xml
@@ -30,17 +30,4 @@
         <module>cli</module>
     </modules>
 
-    <profiles>
-        <profile>
-            <id>rpmbuild</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>rpm-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/groups/service/pom.xml
+++ b/groups/service/pom.xml
@@ -227,4 +227,58 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>rpmbuild</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <configuration>
+                            <name>${project.artifactId}</name>
+                            <description>${project.name} RPM</description>
+                            <license>ASL 2.0</license>
+                            <provides>
+                                <provide>ezbake-groups-service-staging-imp = ${version}</provide>
+                            </provides>
+                            <mappings combine.self="override">
+                                <mapping>
+                                    <directory>/opt/ezbake</directory>
+                                    <username>ezbake</username>
+                                    <groupname>ezbake</groupname>
+                                    <filemode>755</filemode>
+                                    <directoryIncluded>true</directoryIncluded>
+                                </mapping>
+                                <mapping>
+                                    <directory>/opt/ezbake/staging</directory>
+                                    <username>ezbake</username>
+                                    <groupname>ezbake</groupname>
+                                    <filemode>755</filemode>
+                                    <directoryIncluded>true</directoryIncluded>
+                                </mapping>
+                                <mapping>
+                                    <directory>/opt/ezbake/staging/${project.artifactId}</directory>
+                                    <username>ezbake</username>
+                                    <groupname>ezbake</groupname>
+                                    <filemode>755</filemode>
+                                    <directoryIncluded>true</directoryIncluded>
+                                </mapping>
+                                <mapping>
+                                    <directory>/opt/ezbake/staging/${project.artifactId}</directory>
+                                    <username>ezbake</username>
+                                    <groupname>ezbake</groupname>
+                                    <filemode>644</filemode>
+                                    <directoryIncluded>false</directoryIncluded>
+                                    <sources>
+                                        <source><location>target/ezbake-groups-service-2.1-thrift-runnable.jar</location></source>
+                                    </sources>
+                                </mapping>
+                            </mappings>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
@joshbronson please take a look. This pom change builds groups staging rpm with the following structure

``` bash
/opt/ezbake
/opt/ezbake/staging
/opt/ezbake/staging/ezbake-groups-service
/opt/ezbake/staging/ezbake-groups-service/ezbake-groups-service-2.1-thrift-runnable.jar
```

I have not included manifest file intentionally as it is better to be furnished by puppet later.
